### PR TITLE
Allow for graceful restart of Calico without workload interruption

### DIFF
--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -106,16 +106,13 @@ protocol direct {
                                           # export cluster IPs.
 }
 
-protocol bfd bfd_global {
+protocol bfd {
   debug { states };
   interface -"cali*", -"kube-ipvs*", "*" {
-    interval 100ms;
-    idle tx interval 1000ms;
     multiplier 5;
   };
   multihop {
-    interval 100ms;
-    multiplier 5;
+    multiplier 7;
   };
 }
 
@@ -135,7 +132,6 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   add paths on;
   graceful restart;  # See comment in kernel section about graceful restart.
-  hold time 30;
   connect delay time 2;
   connect retry time 5;
   error wait time 5,30;
@@ -176,12 +172,8 @@ template bgp bgp_template {
   */ -}}
   {{if gt $onode_ip $node_ip}}
   passive on; # Mesh is unidirectional, peer will connect to us.
-  bfd peer {{$onode_ip}} {
-    passive on;
-  };
-  {{else}}
-  bfd;
   {{- end}}
+  bfd on;
 }{{end}}{{end}}{{end}}
 {{else}}
 # Node-to-node mesh disabled
@@ -207,7 +199,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{- end}}
 {{- if ne $data.restart_time ""}}
   graceful restart time {{$data.restart_time}};
-  bfd graceful;
+  bfd on;
 {{- end}}
 {{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
@@ -244,7 +236,7 @@ protocol bgp Node_{{$id}} from bgp_template {
 {{- end}}
 {{- if ne $data.restart_time ""}}
   graceful restart time {{$data.restart_time}};
-  bfd graceful;
+  bfd on;
 {{- end}}
 {{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -111,12 +111,12 @@ protocol bfd {
   interface -"cali*", -"kube-ipvs*", "*" {
     interval 500 ms;
     idle tx interval 2000 ms;
-    multiplier 6;
+    multiplier 16;
   };
   multihop {
     interval 500 ms;
     idle tx interval 2000 ms;
-    multiplier 6;
+    multiplier 16;
   };
 }
 

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -139,6 +139,7 @@ template bgp bgp_template {
   connect delay time 2;
   connect retry time 5;
   error wait time 5,30;
+  startup hold time 45;
 }
 
 # ------------- Node-to-node mesh -------------

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -134,12 +134,11 @@ template bgp bgp_template {
                      # topology is and therefore have to trust the ToR/RR.
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   add paths on;
-  graceful restart time 5;  # See comment in kernel section about graceful restart.
+  graceful restart;  # See comment in kernel section about graceful restart.
   hold time 30;
   connect delay time 2;
   connect retry time 5;
   error wait time 5,30;
-  bfd on;
 }
 
 # ------------- Node-to-node mesh -------------
@@ -178,6 +177,7 @@ template bgp bgp_template {
   {{if gt $onode_ip $node_ip}}
   passive on; # Mesh is unidirectional, peer will connect to us.
   {{- end}}
+  bfd on;
 }{{end}}{{end}}{{end}}
 {{else}}
 # Node-to-node mesh disabled
@@ -203,6 +203,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{- end}}
 {{- if ne $data.restart_time ""}}
   graceful restart time {{$data.restart_time}};
+  bfd on;
 {{- end}}
 {{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
@@ -239,6 +240,7 @@ protocol bgp Node_{{$id}} from bgp_template {
 {{- end}}
 {{- if ne $data.restart_time ""}}
   graceful restart time {{$data.restart_time}};
+  bfd on;
 {{- end}}
 {{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -109,9 +109,14 @@ protocol direct {
 protocol bfd {
   debug { states };
   interface -"cali*", -"kube-ipvs*", "*" {
-    interval 300 ms;
+    interval 1000 ms;
     idle tx interval 2000 ms;
-    multiplier 10;
+    multiplier 3;
+  };
+  multihop {
+    interval 1000 ms;
+    idle tx interval 2000 ms;
+    multiplier 3;
   };
 }
 
@@ -124,6 +129,7 @@ template bgp bgp_template {
 {{- template "LOGGING"}}
   description "Connection to BGP peer";
   local as {{$node_as_num}};
+  multihop;
   gateway recursive; # This should be the default, but just in case.
   import all;        # Import all routes, since we don't know what the upstream
                      # topology is and therefore have to trust the ToR/RR.
@@ -192,7 +198,6 @@ template bgp bgp_template {
 {{- else}}
 protocol bgp Global_{{$id}} from bgp_template {
   neighbor {{$data.ip}} {{if $data.port }}port {{ $data.port }} {{end}}as {{$data.as_num}};
-  multihop;
 {{- if eq $data.source_addr "UseNodeIP"}}
   source address {{$node_ip}};  # The local address we use for the TCP connection
 {{- end}}
@@ -230,7 +235,6 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{- else}}
 protocol bgp Node_{{$id}} from bgp_template {
   neighbor {{$data.ip}} {{if $data.port }}port {{ $data.port }} {{end}}as {{$data.as_num}};
-  multihop;
 {{- if eq $data.source_addr "UseNodeIP"}}
   source address {{$node_ip}};  # The local address we use for the TCP connection
 {{- end}}

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -107,7 +107,7 @@ protocol direct {
 }
 
 protocol bfd bfd_global {
-{{- template "LOGGING"}}
+  debug { states };
   interface -"cali*", -"kube-ipvs*", "*" {
     interval 100ms;
     idle tx interval 1000ms;

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -109,10 +109,14 @@ protocol direct {
 protocol bfd {
   debug { states };
   interface -"cali*", -"kube-ipvs*", "*" {
-    multiplier 5;
+    interval 300 ms;
+    idle tx interval 2000 ms;
+    multiplier 10;
   };
   multihop {
-    multiplier 7;
+    interval 300 ms;
+    idle tx interval 2000 ms;
+    multiplier 20;
   };
 }
 

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -177,7 +177,7 @@ template bgp bgp_template {
   {{if gt $onode_ip $node_ip}}
   passive on; # Mesh is unidirectional, peer will connect to us.
   {{- end}}
-  bfd on;
+  bfd graceful;
 }{{end}}{{end}}{{end}}
 {{else}}
 # Node-to-node mesh disabled
@@ -203,7 +203,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{- end}}
 {{- if ne $data.restart_time ""}}
   graceful restart time {{$data.restart_time}};
-  bfd on;
+  bfd graceful;
 {{- end}}
 {{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
@@ -240,7 +240,7 @@ protocol bgp Node_{{$id}} from bgp_template {
 {{- end}}
 {{- if ne $data.restart_time ""}}
   graceful restart time {{$data.restart_time}};
-  bfd on;
+  bfd graceful;
 {{- end}}
 {{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -109,14 +109,14 @@ protocol direct {
 protocol bfd {
   debug { states };
   interface -"cali*", -"kube-ipvs*", "*" {
-    interval 1000 ms;
+    interval 500 ms;
     idle tx interval 2000 ms;
-    multiplier 3;
+    multiplier 6;
   };
   multihop {
-    interval 1000 ms;
+    interval 500 ms;
     idle tx interval 2000 ms;
-    multiplier 3;
+    multiplier 6;
   };
 }
 
@@ -136,7 +136,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   add paths on;
   graceful restart;  # See comment in kernel section about graceful restart.
-  connect delay time 2;
+  connect delay time 4;
   connect retry time 5;
   error wait time 5,30;
 }

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -176,8 +176,12 @@ template bgp bgp_template {
   */ -}}
   {{if gt $onode_ip $node_ip}}
   passive on; # Mesh is unidirectional, peer will connect to us.
+  bfd peer {{$onode_ip}} {
+    passive on;
+  };
+  {{else}}
+  bfd;
   {{- end}}
-  bfd graceful;
 }{{end}}{{end}}{{end}}
 {{else}}
 # Node-to-node mesh disabled

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -166,7 +166,7 @@ template bgp bgp_template {
 {{if eq $onode_ip ($node_ip) }}# Skipping ourselves ({{$node_ip}})
 {{- else if ne "" ($onode_cluster_id)}}# Skipping {{$onode_ip}} ({{.}}) as it is a route reflector with cluster ID {{$onode_cluster_id}}
 {{else if ne "" $onode_ip}}protocol bgp Mesh_{{$id}} from bgp_template {
-  neighbor {{$onode_ip}} {{if ne "" $listen_port}}port {{$listen_port}} {{end}}as {{if exists $onode_as_key}}{{getv $onode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
+  neighbor {{$onode_ip}} {{if ne "" $listen_port}}port {{$listen_port}} {{end}}as {{if exists $onode_as_key}}{{getv $onode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}} multihop off;
   source address {{$node_ip}};  # The local address we use for the TCP connection
   {{- /*
        Make the peering unidirectional. This avoids a race where

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -177,7 +177,8 @@ template bgp bgp_template {
   {{if gt $onode_ip $node_ip}}
   passive on; # Mesh is unidirectional, peer will connect to us.
   {{- end}}
-  bfd on;
+  graceful restart time 120;
+  bfd graceful;
 }{{end}}{{end}}{{end}}
 {{else}}
 # Node-to-node mesh disabled
@@ -203,7 +204,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{- end}}
 {{- if ne $data.restart_time ""}}
   graceful restart time {{$data.restart_time}};
-  bfd on;
+  bfd graceful;
 {{- end}}
 {{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;
@@ -240,7 +241,7 @@ protocol bgp Node_{{$id}} from bgp_template {
 {{- end}}
 {{- if ne $data.restart_time ""}}
   graceful restart time {{$data.restart_time}};
-  bfd on;
+  bfd graceful;
 {{- end}}
 {{- if and (eq $data.as_num $node_as_num) (ne "" ($node_cluster_id)) (ne $data.rr_cluster_id ($node_cluster_id))}}
   rr client;

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -52,16 +52,16 @@ listen bgp port {{getv "/global/listen_port"}};
 {{- end}}
 
 {{- define "LOGGING"}}
-{{- $node_logging_key := printf "/host/%s/loglevel" (getenv "NODENAME")}}
+{{- $node_logging_key := "debug"}}
 {{- if exists $node_logging_key}}
-{{- $logging := getv $node_logging_key}}
+{{- $logging := "debug"}}
 {{- if eq $logging "debug"}}
   debug all;
 {{- else if ne $logging "none"}}
   debug { states };
 {{- end}}
 {{- else if exists "/global/loglevel"}}
-{{- $logging := getv "/global/loglevel"}}
+{{- $logging := "debug"}}
 {{- if eq $logging "debug"}}
   debug all;
 {{- else if ne $logging "none"}}
@@ -90,7 +90,6 @@ protocol kernel {
 
 # Watch interface up/down events.
 protocol device {
-{{- template "LOGGING"}}
   scan time 2;    # Scan interfaces every 2 seconds
 }
 
@@ -108,6 +107,7 @@ protocol direct {
 }
 
 protocol bfd bfd_global {
+{{- template "LOGGING"}}
   interface -"cali*", -"kube-ipvs*", "*" {
     interval 100ms;
     idle tx interval 1000ms;

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -113,11 +113,6 @@ protocol bfd {
     idle tx interval 2000 ms;
     multiplier 10;
   };
-  multihop {
-    interval 300 ms;
-    idle tx interval 2000 ms;
-    multiplier 20;
-  };
 }
 
 {{if eq "" ($node_ip)}}# IPv4 disabled on this node.

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -129,7 +129,6 @@ template bgp bgp_template {
 {{- template "LOGGING"}}
   description "Connection to BGP peer";
   local as {{$node_as_num}};
-  multihop;
   gateway recursive; # This should be the default, but just in case.
   import all;        # Import all routes, since we don't know what the upstream
                      # topology is and therefore have to trust the ToR/RR.
@@ -166,7 +165,7 @@ template bgp bgp_template {
 {{if eq $onode_ip ($node_ip) }}# Skipping ourselves ({{$node_ip}})
 {{- else if ne "" ($onode_cluster_id)}}# Skipping {{$onode_ip}} ({{.}}) as it is a route reflector with cluster ID {{$onode_cluster_id}}
 {{else if ne "" $onode_ip}}protocol bgp Mesh_{{$id}} from bgp_template {
-  neighbor {{$onode_ip}} {{if ne "" $listen_port}}port {{$listen_port}} {{end}}as {{if exists $onode_as_key}}{{getv $onode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}} multihop off;
+  neighbor {{$onode_ip}} {{if ne "" $listen_port}}port {{$listen_port}} {{end}}as {{if exists $onode_as_key}}{{getv $onode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
   source address {{$node_ip}};  # The local address we use for the TCP connection
   {{- /*
        Make the peering unidirectional. This avoids a race where
@@ -198,6 +197,7 @@ template bgp bgp_template {
 {{- else}}
 protocol bgp Global_{{$id}} from bgp_template {
   neighbor {{$data.ip}} {{if $data.port }}port {{ $data.port }} {{end}}as {{$data.as_num}};
+  multihop;
 {{- if eq $data.source_addr "UseNodeIP"}}
   source address {{$node_ip}};  # The local address we use for the TCP connection
 {{- end}}
@@ -235,6 +235,7 @@ protocol bgp Global_{{$id}} from bgp_template {
 {{- else}}
 protocol bgp Node_{{$id}} from bgp_template {
   neighbor {{$data.ip}} {{if $data.port }}port {{ $data.port }} {{end}}as {{$data.as_num}};
+  multihop;
 {{- if eq $data.source_addr "UseNodeIP"}}
   source address {{$node_ip}};  # The local address we use for the TCP connection
 {{- end}}

--- a/confd/etc/calico/confd/templates/bird.cfg.template
+++ b/confd/etc/calico/confd/templates/bird.cfg.template
@@ -139,7 +139,6 @@ template bgp bgp_template {
   connect delay time 2;
   connect retry time 5;
   error wait time 5,30;
-  startup hold time 45;
 }
 
 # ------------- Node-to-node mesh -------------

--- a/lib.Makefile
+++ b/lib.Makefile
@@ -234,7 +234,11 @@ endif
 DOCKER_BUILD=docker buildx build --pull \
 	     --build-arg QEMU_IMAGE=$(CALICO_BUILD) \
 	     --build-arg UBI_IMAGE=$(UBI_IMAGE) \
-	     --build-arg GIT_VERSION=$(GIT_VERSION) $(TARGET_PLATFORM)
+	     --build-arg GIT_VERSION=$(GIT_VERSION) $(TARGET_PLATFORM) \
+	     --label org.opencontainers.image.source="https://github.com/powerhome/calico" \
+	     --label org.opencontainers.image.version=$(GIT_VERSION) \
+	     --label org.opencontainers.image.revision=$(GIT_COMMIT) \
+	     --label org.opencontainers.image.licenses="Apache-2.0"
 
 DOCKER_RUN := mkdir -p ../.go-pkg-cache bin $(GOMOD_CACHE) && \
 	docker run --rm \
@@ -1149,4 +1153,3 @@ help:
 	@echo "BUILDARCH (host):	$(BUILDARCH)"
 	@echo "CALICO_BUILD:		$(CALICO_BUILD)"
 	@echo "-----------------------------------------------------------"
-

--- a/node/clean-up-filesystem.sh
+++ b/node/clean-up-filesystem.sh
@@ -228,6 +228,7 @@ done < <(find /usr/lib64 \( -type f -or -type l \))
 # binaries and libraries that we don't want.
 packages_to_keep=(
   bash
+  bzip2-libs
   ca-certificates
   conntrack-tools
   coreutils-single


### PR DESCRIPTION
This mostly boils down to deciphering the more than two decade-old documentation of BIRD < 2.0. BFD behavior was fixed and timers tuned. Some timers will still merit further attention later, but this in itself is already a huge improvement. I haven't included further filtering here because it still needs further attention with more than one AS in the AS_PATH.